### PR TITLE
Render has no cache support for docker builds hence build failure was happening.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM gradle:8.5.0-jdk17-alpine
+FROM openjdk:17-slim
 
 COPY . .
 
-RUN gradle clean build
+RUN ./gradlew clean build
 
 COPY build/libs/booky-0.0.1-SNAPSHOT.jar ./booky.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ COPY . .
 
 RUN ./gradlew clean build
 
-COPY build/libs/booky-0.0.1-SNAPSHOT.jar ./booky.jar
-
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "booky.jar"]
+ENTRYPOINT ["java", "-jar", "./build/libs/booky-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ COPY . .
 
 RUN gradle clean build
 
-COPY ./build/libs/booky-0.0.1-SNAPSHOT.jar ./booky.jar
+COPY build/libs/booky-0.0.1-SNAPSHOT.jar ./booky.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "./booky.jar"]
+ENTRYPOINT ["java", "-jar", "booky.jar"]


### PR DESCRIPTION
removed the copy command and now it directly runs after building.